### PR TITLE
Fix examples to Terraform Module Registry source format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Terraform module for creating AWS IAM Roles with inline (heredoc) syntax
 ### EC2
 ```HCL
 module "iam" {
-  source = "baikonur-oss/terraform-aws-iam-nofile?ref=v1.0.0"
+  source  = "baikonur-oss/iam-nofile/aws"
+  
   type   = "ec2"
   name   = "ec2-instance"
   policy_json = <<EOF
@@ -44,7 +45,8 @@ EOF
 ### Lambda
 ```HCL
 module "iam" {
-  source = "baikonur-oss/terraform-aws-iam-nofile?ref=v1.0.0"
+  source  = "baikonur-oss/iam-nofile/aws"
+  
   type   = "lambda"
   name   = "lambda-function"
 
@@ -72,8 +74,14 @@ EOF
 ```
 
 ### Version pinning
-Make sure to use `?ref=` version pinning in module source URI.
-This will save you from a lot of troubles.
+#### Terraform Module Registry
+Use `version` parameter to pin to a specific version, or to specify a version constraint when pulling from [Terraform Module Registry](https://registry.terraform.io) (`source = baikonur-oss/iam-nofile/aws`).
+For more information, refer to [Module Versions](https://www.terraform.io/docs/configuration/modules.html#module-versions) section of Terraform Modules documentation.
+
+#### GitHub URI
+Make sure to use `?ref=` version pinning in module source URI when pulling from GitHub.
+Pulling from GitHub is especially useful for development, as you can pin to a specific branch, tag or commit hash.
+Example: `source = baikonur-oss/terraform-aws-iam-nofile?ref=v1.0.0`
 
 For more information on module version pinning, see [Selecting a Revision](https://www.terraform.io/docs/modules/sources.html#selecting-a-revision) section of Terraform Modules documentation.
 


### PR DESCRIPTION
As we have published this repo [here](https://registry.terraform.io/modules/baikonur-oss/iam-nofile/aws/1.0.0), we can write source parameter smarter.

This PR proposes Module Registry style imports and additional information on version pinning