### PR TITLE
Prepare 0.12-only release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.7.3
+  rev: v1.16.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform module for creating AWS IAM Roles with inline (heredoc) syntax
 
-![terraform v0.11.x](https://img.shields.io/badge/terraform-v0.11.x-brightgreen.svg)
+![terraform v0.12.x](https://img.shields.io/badge/terraform-v0.12.x-brightgreen.svg)
 
 ## Usage
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,14 +1,14 @@
 variable "name" {
   description = "Resource name"
-  type        = "string"
+  type        = string
 }
 
 variable "type" {
   description = "IAM Role type: ec2/lambda/etc. Used for assume_role_policy principal; service names that have *.amazonaws.com identifiers should work."
-  type        = "string"
+  type        = string
 }
 
 variable "policy_json" {
   description = "IAM Role Policy Document (JSON)"
-  type        = "string"
+  type        = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Newer Terraform v0.12.x versions give warnings if we use HCL1 syntax. Almost all other modules depend on this module, so we have to fix this too.

Breaks support for v0.11.x, will tag v2.0.